### PR TITLE
patch for data race

### DIFF
--- a/cmd/align.go
+++ b/cmd/align.go
@@ -43,7 +43,7 @@ var alignCmd = &cobra.Command{
 func init() {
 	fastq = alignCmd.Flags().StringSliceP("fastq", "f", []string{}, "FASTQ file(s) to align")
 	fasta = alignCmd.Flags().Bool("fasta", false, "if set, the input will be treated as fasta sequence(s) (experimental feature)")
-	noAlign = alignCmd.Flags().Bool("noAlign", false, "it set, no exact alignment will be performed - graphs will be weighted using approximated read mappings")
+	noAlign = alignCmd.Flags().Bool("noAlign", false, "if set, no exact alignment will be performed - graphs will be weighted using approximate read mappings")
 	containmentThreshold = alignCmd.Flags().Float64P("contThresh", "t", 0.99, "containment threshold for the LSH ensemble")
 	minKmerCoverage = alignCmd.Flags().Float64P("minKmerCov", "c", 1.0, "minimum number of k-mers covering each base of a graph segment")
 	graphDir = alignCmd.PersistentFlags().StringP("graphDir", "g", defaultGraphDir, "directory to save variation graphs to")

--- a/cmd/align.go
+++ b/cmd/align.go
@@ -19,6 +19,7 @@ import (
 var (
 	fastq                *[]string                                                         // list of FASTQ files to align
 	fasta                *bool                                                             // flag to treat input as fasta sequences
+	noAlign              *bool                                                             // flag to prevent exact alignments
 	containmentThreshold *float64                                                          // the containment threshold for the LSH ensemble
 	minKmerCoverage      *float64                                                          // the minimum k-mer coverage per base of a segment
 	graphDir             *string                                                           // directory to save gfa graphs to
@@ -42,6 +43,7 @@ var alignCmd = &cobra.Command{
 func init() {
 	fastq = alignCmd.Flags().StringSliceP("fastq", "f", []string{}, "FASTQ file(s) to align")
 	fasta = alignCmd.Flags().Bool("fasta", false, "if set, the input will be treated as fasta sequence(s) (experimental feature)")
+	noAlign = alignCmd.Flags().Bool("noAlign", false, "it set, no exact alignment will be performed - graphs will be weighted using approximated read mappings")
 	containmentThreshold = alignCmd.Flags().Float64P("contThresh", "t", 0.99, "containment threshold for the LSH ensemble")
 	minKmerCoverage = alignCmd.Flags().Float64P("minKmerCov", "c", 1.0, "minimum number of k-mers covering each base of a graph segment")
 	graphDir = alignCmd.PersistentFlags().StringP("graphDir", "g", defaultGraphDir, "directory to save variation graphs to")
@@ -115,8 +117,12 @@ func runSketch() {
 	info.Sketch = pipeline.AlignCmd{
 		Fasta:           *fasta,
 		MinKmerCoverage: *minKmerCoverage,
+		NoExactAlign:    *noAlign,
 	}
 	log.Printf("\tcontainment threshold: %.2f\n", info.ContainmentThreshold)
+	if *noAlign {
+		log.Printf("\tprevent exact alignments and using approximated mapping only\n")
+	}
 
 	// create the pipeline
 	log.Printf("initialising alignment pipeline...")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,7 @@ author = 'Will Rowe'
 # The short X.Y version
 version = '1.1'
 # The full version, including alpha/beta/rc tags
-release = '1.1.0'
+release = '1.1.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/using-groot.md
+++ b/docs/using-groot.md
@@ -120,6 +120,10 @@ gunzip -c file.gz | ./groot align -i grootIndex -p 8 | ./groot report
 
 Multiple FASTQ files can be specified as input, however all are treated as the same sample and paired-end info isn't used. To specify multiple files, make sure they are comma separated (`-f fileA.fq,fileB.fq`) or use gunzip/cat with a wildcard (gunzip -c \*.fq.gz | groot...).
 
+Some more flags that can be used:
+
+- `--noAlign`: if set, no exact alignment will be performed (graphs will still be weighted using approximate read mappings)
+
 ### report
 
 The `report` subcommand is used to processes graph traversals and generate a resistome profile for a sample. Here is an example:

--- a/src/pipeline/sketch.go
+++ b/src/pipeline/sketch.go
@@ -311,15 +311,6 @@ func (proc *ReadMapper) Run() {
 	// set up the boss/minion pool
 	theBoss := newBoss(proc.info, proc.input)
 
-	// update the BAM from STDOUT if needed (TODO: not exposed to CLI yet)
-	if proc.info.Sketch.BAMout != "" {
-		fh, err := os.Create(proc.info.Sketch.BAMout)
-		if err != nil {
-			misc.ErrorCheck(fmt.Errorf("could not open file for BAM writing: %v", err))
-		}
-		theBoss.outFile = fh
-	}
-
 	// run the mapping
 	misc.ErrorCheck(theBoss.mapReads())
 

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -9,7 +9,7 @@ const major = 1
 const minor = 1
 
 // patch is the patch version number
-const patch = 1
+const patch = 2
 
 // GetVersion returns the full version string for the current GROOT software
 func GetVersion() string {


### PR DESCRIPTION
Data race occurs when a read maps to multiple graphs and read needs to be reverse complemented in each Go routine. This PR fixes that and also adds a flag to skip exact alignments during the align subcommand, leaving only approximate mappings.